### PR TITLE
Fix swapByteOrder prototype.

### DIFF
--- a/canard_internals.h
+++ b/canard_internals.h
@@ -111,7 +111,7 @@ CANARD_INTERNAL int16_t descatterTransferPayload(const CanardRxTransfer* transfe
 
 CANARD_INTERNAL bool isBigEndian(void);
 
-CANARD_INTERNAL void swapByteOrder(void* data, unsigned size);
+CANARD_INTERNAL void swapByteOrder(void* data, size_t size);
 
 /*
  * Transfer CRC


### PR DESCRIPTION
On some platforms, unsigned type is not the same as size_t.