### PR TITLE
Add canardForgetLocalNodeID()

### DIFF
--- a/canard.c
+++ b/canard.c
@@ -133,6 +133,10 @@ uint8_t canardGetLocalNodeID(const CanardInstance* ins)
     return ins->node_id;
 }
 
+void canardForgetLocalNodeID(CanardInstance* ins) {
+    ins->node_id = CANARD_BROADCAST_NODE_ID;
+}
+
 int16_t canardBroadcast(CanardInstance* ins,
                         uint64_t data_type_signature,
                         uint16_t data_type_id,

--- a/canard.h
+++ b/canard.h
@@ -394,6 +394,11 @@ void canardSetLocalNodeID(CanardInstance* ins,
 uint8_t canardGetLocalNodeID(const CanardInstance* ins);
 
 /**
+ * Forgets the current node ID value so that a new Node ID can be assigned.
+ */
+void canardForgetLocalNodeID(CanardInstance* ins);
+
+/**
  * Sends a broadcast transfer.
  * If the node is in passive mode, only single frame transfers will be allowed (they will be transmitted as anonymous).
  *


### PR DESCRIPTION
This function will set the Node ID to CANARD_BROADCAST_NODE_ID so that the Node ID can be reassigned with another call to canardSetLocalNodeID()