### PR TITLE
Fix wrong parameter type in swapByteOrder()

### DIFF
--- a/canard_internals.h
+++ b/canard_internals.h
@@ -117,7 +117,7 @@ CANARD_INTERNAL int16_t descatterTransferPayload(const CanardRxTransfer* transfe
 
 CANARD_INTERNAL bool isBigEndian(void);
 
-CANARD_INTERNAL void swapByteOrder(void* data, unsigned size);
+CANARD_INTERNAL void swapByteOrder(void* data, size_t size);
 
 /*
  * Transfer CRC


### PR DESCRIPTION
There is a mismatch of the type for the `size` parameter between the declaration of `swapByteOrder()` in the header and its definition in the .c file, which causes a warning during compilation. This fixes it.

https://github.com/dronecan/libcanard/blob/f646cdd9345c79b2d144056dcce0fd342a3da12f/canard_internals.h#L120
https://github.com/dronecan/libcanard/blob/f646cdd9345c79b2d144056dcce0fd342a3da12f/canard.c#L1604