### PR TITLE
fixed assert caused by addition of iface_id variable to CanardRxState

### DIFF
--- a/canard.c
+++ b/canard.c
@@ -85,7 +85,7 @@ void canardInit(CanardInstance* out_ins,
      * If your application fails here, make sure it's not built in 64-bit mode.
      * Refer to the design documentation for more info.
      */
-    CANARD_ASSERT(CANARD_MULTIFRAME_RX_PAYLOAD_HEAD_SIZE >= 6);
+    CANARD_ASSERT(CANARD_MULTIFRAME_RX_PAYLOAD_HEAD_SIZE >= 5);
 
     memset(out_ins, 0, sizeof(*out_ins));
 


### PR DESCRIPTION
fix of regression: static assert caused by addition of iface_id variable to CanardRxState in https://github.com/dronecan/libcanard/commit/4e866a24c810a114fda75c9e271c3d3f252456a6#diff-37a3e1f6b7d78a1054dc026a14cdefba83950e12ed0773a36ea26aacc6687237 line 276