### PR TITLE
update canardCleanupStaleTransfers to cleanup stale tx as well

### DIFF
--- a/canard.c
+++ b/canard.c
@@ -34,8 +34,8 @@
 #define MAX(a, b)   (((a) > (b)) ? (a) : (b))
 
 
-#define TRANSFER_TIMEOUT_USEC                       2000000
-#define IFACE_SWITCH_DELAY_USEC                     1000000
+#define TRANSFER_TIMEOUT_USEC                       2000000U
+#define IFACE_SWITCH_DELAY_USEC                     1000000U
 
 #define TRANSFER_ID_BIT_LEN                         5U
 #define ANON_MSG_DATA_TYPE_ID_BIT_LEN               2U

--- a/canard.c
+++ b/canard.c
@@ -220,7 +220,9 @@ int16_t canardBroadcastObj(CanardInstance* ins, CanardTxTransfer* transfer_objec
 
     const int16_t result = enqueueTxFrames(ins, can_id, crc, transfer_object);
 
-    incrementTransferID(transfer_object->inout_transfer_id);
+    if (result > 0) {
+        incrementTransferID(transfer_object->inout_transfer_id);
+    }
 
     return result;
 }
@@ -374,7 +376,7 @@ int16_t canardRequestOrRespondObj(CanardInstance* ins, uint8_t destination_node_
 
     const int16_t result = enqueueTxFrames(ins, can_id, crc, transfer_object);
 
-    if (transfer_object->transfer_type == CanardTransferTypeRequest)                      // Response Transfer ID must not be altered
+    if (result > 0 && transfer_object->transfer_type == CanardTransferTypeRequest)                      // Response Transfer ID must not be altered
     {
         incrementTransferID(transfer_object->inout_transfer_id);
     }

--- a/canard.h
+++ b/canard.h
@@ -68,8 +68,13 @@ extern "C" {
 
 /// By default this macro resolves to the standard assert(). The user can redefine this if necessary.
 #ifndef CANARD_ASSERT
-# define CANARD_ASSERT(x)   assert(x)
+#ifdef CANARD_ENABLE_ASSERTS
+ #error assertsenabled
+# define CANARD_ASSERT(x) assert(x)
+#else
+# define CANARD_ASSERT(x)
 #endif
+#endif // CANARD_ASSERT
 
 #define CANARD_GLUE(a, b)           CANARD_GLUE_IMPL_(a, b)
 #define CANARD_GLUE_IMPL_(a, b)     a##b

--- a/canard/publisher.h
+++ b/canard/publisher.h
@@ -116,7 +116,7 @@ public:
         );
         // send the message if encoded successfully
         if (len > 0) {
-            Transfer msg_transfer;
+            Transfer msg_transfer {};
             msg_transfer.transfer_type = CanardTransferTypeBroadcast;
             msg_transfer.data_type_id = msgtype::cxx_iface::ID;
             msg_transfer.data_type_signature = msgtype::cxx_iface::SIGNATURE;

--- a/canard/tests/CMakeLists.txt
+++ b/canard/tests/CMakeLists.txt
@@ -21,6 +21,20 @@ execute_process(COMMAND python3 ${dronecan_dsdlc_SOURCE_DIR}/dronecan_dsdlc.py
     ${dsdl_SOURCE_DIR}/com
     )
 
+if (CANARD_ENABLE_DEADLINE)
+    add_definitions(-DCANARD_ENABLE_DEADLINE=1)
+endif()
+
+# check arguments for 32-bit build
+if (CMAKE_32BIT)
+     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
+endif()
+
+if (CANARD_ENABLE_CANFD)
+    add_definitions(-DCANARD_ENABLE_CANFD=1)
+endif()
+
 # generate dsdl messages
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/dsdlc_generated/include)
 

--- a/canard/tests/canard_interface.cpp
+++ b/canard/tests/canard_interface.cpp
@@ -15,7 +15,7 @@ bool CanardInterface::broadcast(const Transfer &bcast_transfer) {
     // get current time in microseconds
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
-    uint64_t timestamp_usec = ts.tv_sec * 1000000ULL + ts.tv_nsec / 1000ULL;
+    uint64_t timestamp_usec = uint64_t(ts.tv_sec) * 1000000ULL + uint64_t(ts.tv_nsec) / 1000ULL;
 #endif
     // do canard broadcast
     CanardTxTransfer tx_transfer = {
@@ -29,7 +29,9 @@ bool CanardInterface::broadcast(const Transfer &bcast_transfer) {
 #if CANARD_ENABLE_CANFD
         .canfd = bcast_transfer.canfd,
 #endif
-
+#if CANARD_ENABLE_DEADLINE
+        .deadline_usec = timestamp_usec + (bcast_transfer.timeout_ms*1000),
+#endif
 #if CANARD_MULTI_IFACE
         .iface_mask = CANARD_IFACE_ALL,
 #endif
@@ -43,7 +45,7 @@ bool CanardInterface::request(uint8_t destination_node_id, const Transfer &req_t
     // get current time in microseconds
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
-    uint64_t timestamp_usec = ts.tv_sec * 1000000ULL + ts.tv_nsec / 1000ULL;
+    uint64_t timestamp_usec = uint64_t(ts.tv_sec) * 1000000ULL + uint64_t(ts.tv_nsec) / 1000ULL;
 #endif
 
     // do canard request
@@ -73,7 +75,7 @@ bool CanardInterface::respond(uint8_t destination_node_id, const Transfer &res_t
     // get current time in microseconds
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
-    uint64_t timestamp_usec = ts.tv_sec * 1000000ULL + ts.tv_nsec / 1000ULL;
+    uint64_t timestamp_usec = uint64_t(ts.tv_sec) * 1000000ULL + uint64_t(ts.tv_nsec) / 1000ULL;
 #endif
     // do canard respond
     CanardTxTransfer tx_transfer = {

--- a/canard/tests/canard_interface.cpp
+++ b/canard/tests/canard_interface.cpp
@@ -57,11 +57,11 @@ bool CanardInterface::request(uint8_t destination_node_id, const Transfer &req_t
         .priority = req_transfer.priority,
         .payload = (const uint8_t*)req_transfer.payload,
         .payload_len = (uint16_t)req_transfer.payload_len,
-#if CANARD_ENABLE_DEADLINE
-        .deadline_usec = timestamp_usec + (req_transfer.timeout_ms*1000),
-#endif
 #if CANARD_ENABLE_CANFD
         .canfd = req_transfer.canfd,
+#endif
+#if CANARD_ENABLE_DEADLINE
+        .deadline_usec = timestamp_usec + (req_transfer.timeout_ms*1000),
 #endif
 #if CANARD_MULTI_IFACE
         .iface_mask = CANARD_IFACE_ALL,
@@ -86,11 +86,11 @@ bool CanardInterface::respond(uint8_t destination_node_id, const Transfer &res_t
         .priority = res_transfer.priority,
         .payload = (const uint8_t*)res_transfer.payload,
         .payload_len = (uint16_t)res_transfer.payload_len,
-#if CANARD_ENABLE_DEADLINE
-        .deadline_usec = timestamp_usec + (res_transfer.timeout_ms*1000),
-#endif
 #if CANARD_ENABLE_CANFD
         .canfd = res_transfer.canfd,
+#endif
+#if CANARD_ENABLE_DEADLINE
+        .deadline_usec = timestamp_usec + (res_transfer.timeout_ms*1000),
 #endif
 #if CANARD_MULTI_IFACE
         .iface_mask = CANARD_IFACE_ALL,

--- a/canard/tests/canard_interface.h
+++ b/canard/tests/canard_interface.h
@@ -49,7 +49,6 @@ public:
 
     uint8_t get_node_id() const override { return canard.node_id; }
 
-protected:
     CanardInstance canard {};
 };
 

--- a/canard/tests/test_canard_interface.cpp
+++ b/canard/tests/test_canard_interface.cpp
@@ -258,12 +258,14 @@ TEST(StaticCanardTest, test_multiple_clients) {
     CANARD_TEST_INTERFACE(1).free();
 }
 
+#if CANARD_ENABLE_DEADLINE
 static uint8_t test_var = 0;
 static void test_node_status_server_callback(const CanardRxTransfer &transfer, const uavcan_protocol_NodeStatus &req) {
+    (void)transfer;
+    (void)req;
     test_var++;
 }
 
-#if CANARD_ENABLE_DEADLINE
 TEST(StaticCanardTest, test_CleanupStaleTransfers)
 {
     CANARD_TEST_INTERFACE_DEFINE(0);

--- a/canard/tests/test_canard_interface.cpp
+++ b/canard/tests/test_canard_interface.cpp
@@ -278,8 +278,8 @@ TEST(StaticCanardTest, test_CleanupStaleTransfers)
     node_status.sub_mode = 4;
     node_status.vendor_specific_status_code = 5;
 
-    uint8_t buffer0[2048] {};
-    uint8_t buffer1[2048] {};
+    uint8_t buffer0[4096] {};
+    uint8_t buffer1[4096] {};
     CANARD_TEST_INTERFACE(0).init(buffer0, sizeof(buffer0));
     CANARD_TEST_INTERFACE(1).init(buffer1, sizeof(buffer1));
 
@@ -298,7 +298,7 @@ TEST(StaticCanardTest, test_CleanupStaleTransfers)
         } else {
             node_status_pub_0.set_timeout_ms(1);
         }
-        node_status_pub_0.broadcast(node_status);
+        ASSERT_TRUE(node_status_pub_0.broadcast(node_status));
     }
     // sleep for 2ms
     usleep(2000);

--- a/canard/tests/test_canard_interface.cpp
+++ b/canard/tests/test_canard_interface.cpp
@@ -305,7 +305,7 @@ TEST(StaticCanardTest, test_CleanupStaleTransfers)
     // current time in us
     timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
-    uint64_t timestamp = (ts.tv_sec * 1000000ULL) + (ts.tv_nsec / 1000ULL);
+    uint64_t timestamp = uint64_t(ts.tv_sec) * 1000000ULL + uint64_t(ts.tv_nsec) / 1000ULL;
     // cleanup stale transfers
     canardCleanupStaleTransfers(&CANARD_TEST_INTERFACE(0).canard, timestamp);
     // update tx

--- a/run_test.sh
+++ b/run_test.sh
@@ -34,7 +34,7 @@ function run_cmake() {
     popd
 }
 
-OPTIONS=( CANARD_ENABLE_CANFD CANARD_ENABLE_DEADLINE CANARD_MULTI_IFACE )
+OPTIONS=( CMAKE_32BIT CANARD_ENABLE_CANFD CANARD_ENABLE_DEADLINE CANARD_MULTI_IFACE )
 
 # if no argument is given, run all possible combinations
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
* Currently in Ardupilot DroneCAN library we only pop tx items if they expire and are at the top.
* This PR updates canardCleanupStaleTransfers to include full cleanup of stale transfers both for tx and rx