### PR TITLE
Multiframe transfer assert expression correction

### DIFF
--- a/canard.c
+++ b/canard.c
@@ -601,7 +601,7 @@ int16_t canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, ui
                 CANARD_ASSERT(block != NULL);
 
                 const size_t offset_within_block = rx_state->payload_len - offset;
-                CANARD_ASSERT(offset_within_block < CANARD_BUFFER_BLOCK_DATA_SIZE);
+                CANARD_ASSERT(offset_within_block <= CANARD_BUFFER_BLOCK_DATA_SIZE);
 
                 for (size_t i = offset_within_block;
                      (i < CANARD_BUFFER_BLOCK_DATA_SIZE) && (tail_offset < frame_payload_size);


### PR DESCRIPTION
This pull request modifies an assert check targeting an underflow condition in multi-frame transfer receive processing. The assert aims to detect accidental underflow in a memory offset computation. The assert expression mistakenly invalidates a case where the final CAN frame of a transfer is received with all previously allocated memory blocks fully utilised. This condition requires the base address of the frame data buffer to be assigned to the `rx_transfer.payload_tail` field.

The assert case is triggerable by performing a multi-transfer file read operation using the DroneCAN GUI tool, such as during a firmware update process. The CAN bus is configured in non-CAN-FD mode, with the default memory allocator block size of 32 bytes.