### PR TITLE
socketcan.c: fix missing include

### DIFF
--- a/drivers/socketcan/socketcan.c
+++ b/drivers/socketcan/socketcan.c
@@ -21,6 +21,7 @@
 #include <netpacket/can.h>
 #else
 #include <linux/can.h>
+#include <linux/can/raw.h>
 #endif
 #include <errno.h>
 #include <stdlib.h>


### PR DESCRIPTION
socketcan.c is missing the linux/can/raw.h  include file. The compilation fails when compiled with CANARD_ENABLE_CANFD. The compiler complains about the missing definition of  SOL_CAN_RAW.