### PR TITLE
ensure payload_len is zeroed on start of a new multi-frame packet

### DIFF
--- a/canard.c
+++ b/canard.c
@@ -544,6 +544,7 @@ int16_t canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, ui
 
         // take off the crc and store the payload
         rx_state->timestamp_usec = timestamp_usec;
+        rx_state->payload_len = 0;
         const int16_t ret = bufferBlockPushBytes(&ins->allocator, rx_state, frame->data + 2,
                                                  (uint8_t) (frame->data_len - 3));
         if (ret < 0)

--- a/canard/service_client.h
+++ b/canard/service_client.h
@@ -68,7 +68,10 @@ public:
     /// @param transfer transfer object of the request
     void handle_message(const CanardRxTransfer& transfer) override {
         rsptype msg {};
-        rsptype::cxx_iface::rsp_decode(&transfer, &msg);
+        if (rsptype::cxx_iface::rsp_decode(&transfer, &msg)) {
+            // invalid decode
+            return;
+        }
 
         // scan through the list of entries for corresponding server node id and transfer id
         Client<rsptype>* entry = branch_head[index];

--- a/canard/service_server.h
+++ b/canard/service_server.h
@@ -51,7 +51,10 @@ public:
     /// @param transfer transfer object of the request
     void handle_message(const CanardRxTransfer& transfer) override {
         reqtype msg {};
-        reqtype::cxx_iface::req_decode(&transfer, &msg);
+        if (reqtype::cxx_iface::req_decode(&transfer, &msg)) {
+            // invalid decode
+            return;
+        }
         transfer_id = transfer.transfer_id;
         // call the registered callback
         cb(transfer, msg);

--- a/canard/subscriber.h
+++ b/canard/subscriber.h
@@ -71,7 +71,10 @@ public:
     /// @param transfer transfer object
     void handle_message(const CanardRxTransfer& transfer) override {
         msgtype msg {};
-        msgtype::cxx_iface::decode(&transfer, &msg);
+        if (msgtype::cxx_iface::decode(&transfer, &msg)) {
+            // invalid decode
+            return;
+        }
         // call all registered callbacks in one go
         Subscriber<msgtype>* entry = branch_head[index];
         while (entry != nullptr) {


### PR DESCRIPTION
this ensures that we don't use payload bytes from rejected frames