### PR TITLE
Make GetUserReference pointer argument const

### DIFF
--- a/canard.c
+++ b/canard.c
@@ -101,7 +101,7 @@ void canardInit(CanardInstance* out_ins,
     initPoolAllocator(&out_ins->allocator, mem_arena, (uint16_t)pool_capacity);
 }
 
-void* canardGetUserReference(CanardInstance* ins)
+void* canardGetUserReference(const CanardInstance* ins)
 {
     CANARD_ASSERT(ins != NULL);
     return ins->user_reference;

--- a/canard.h
+++ b/canard.h
@@ -471,7 +471,7 @@ void canardInit(CanardInstance* out_ins,                    ///< Uninitialized l
  * The user pointer is configured once during initialization.
  * It can be used to store references to any user-specific data, or to link the instance object with C++ objects.
  */
-void* canardGetUserReference(CanardInstance* ins);
+void* canardGetUserReference(const CanardInstance* ins);
 
 /**
  * Assigns a new node ID value to the current node.


### PR DESCRIPTION
`canardGetUserReference` doesn't actually modify the `CanardInstance` given as argument.