### PR TITLE
CI fix: pre-exclude source files when analyzing coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,8 +95,7 @@ if(${BUILD_TESTING})
   add_subdirectory(canard/tests)
   if (CANARD_ENABLE_COVERAGE)
     add_custom_target(coverage
-                      COMMAND lcov --directory . --capture --output-file coverage.info
-                      COMMAND lcov --remove coverage.info '/usr/*' '*gtest*' '*tests/*' '*dsdlc_generated/*' --output-file coverage.info
+                      COMMAND lcov --directory . --capture --output-file coverage.info --exclude '/usr/*' --exclude '*gtest*' --exclude '*dsdlc_generated/*' --exclude '*tests/*'
                       COMMAND lcov --list coverage.info
                       COMMAND genhtml coverage.info --output-directory coverage
                       COMMENT echo "Coverage report generated at ${CMAKE_BINARY_DIR}/coverage/index.html"


### PR DESCRIPTION
lcov 2.x, unlike lcov 1.x, gives errors like `geninfo: ERROR: mismatched end line for _ZN12CRC_CRC_Test8TestBodyEv at
/home/runner/work/libcanard/libcanard/tests/test_crc.cpp:42: 42 -> 55` for source files which contain gtest tests.

These files are removed from the coverage information in a later step, but lcov now fails to create the initial coverage info because of them.

Fix this problem (and thus CI) by excluding the files from the initial coverage info instead of removing them later. Note that the exclude order is relevant to ensure all excludes trigger, avoiding errors that some are unused. Verified that identical coverage stats are generated for 2.x as compared to 1.x.