### PR TITLE
fix handler list semaphore and constructor ordering

### DIFF
--- a/canard/handler_list.h
+++ b/canard/handler_list.h
@@ -125,12 +125,12 @@ public:
 protected:
     uint8_t index;
     HandlerList* next;
-
-private:
-    static HandlerList* head[CANARD_NUM_HANDLERS];
 #ifdef WITH_SEMAPHORE
     static Canard::Semaphore sem[CANARD_NUM_HANDLERS];
 #endif
+
+private:
+    static HandlerList* head[CANARD_NUM_HANDLERS];
     uint16_t msgid;
     uint64_t signature;
     CanardTransferType transfer_type;

--- a/canard/service_client.h
+++ b/canard/service_client.h
@@ -46,6 +46,7 @@ public:
 #endif
         next = branch_head[index];
         branch_head[index] = this;
+        link(); // link ourselves into the handler list now that we're in the branch list
     }
 
     // delete copy constructor and assignment operator
@@ -56,6 +57,7 @@ public:
 #ifdef WITH_SEMAPHORE
         WITH_SEMAPHORE(sem[index]);
 #endif
+        unlink(); // unlink ourselves from the handler list before the branch list
         Client<rsptype>* entry = branch_head[index];
         if (entry == this) {
             branch_head[index] = next;

--- a/canard/service_client.h
+++ b/canard/service_client.h
@@ -36,7 +36,7 @@ public:
     /// @brief Client constructor
     /// @param _interface Interface object
     /// @param _cb Callback object
-    Client(Interface &_interface, Callback<rsptype> &_cb) :
+    Client(Interface &_interface, Callback<rsptype> &_cb) NOINLINE_FUNC :
     HandlerList(CanardTransferTypeResponse, rsptype::cxx_iface::ID, rsptype::cxx_iface::SIGNATURE, _interface.get_index()),
     Sender(_interface),
     server_node_id(255),
@@ -53,7 +53,7 @@ public:
     Client(const Client&) = delete;
 
     // destructor, remove the entry from the singly-linked list
-    ~Client() {
+    ~Client() NOINLINE_FUNC {
 #ifdef WITH_SEMAPHORE
         WITH_SEMAPHORE(sem[index]);
 #endif
@@ -74,7 +74,7 @@ public:
 
     /// @brief handles incoming messages
     /// @param transfer transfer object of the request
-    void handle_message(const CanardRxTransfer& transfer) override {
+    void handle_message(const CanardRxTransfer& transfer) override NOINLINE_FUNC {
         rsptype msg {};
         if (rsptype::cxx_iface::rsp_decode(&transfer, &msg)) {
             // invalid decode
@@ -106,7 +106,7 @@ public:
     /// @param msg message containing the request
     /// @param canfd true if CAN FD is to be used
     /// @return true if the request was put into the queue successfully
-    bool request(uint8_t destination_node_id, typename rsptype::cxx_iface::reqtype& msg, bool canfd) {
+    bool request(uint8_t destination_node_id, typename rsptype::cxx_iface::reqtype& msg, bool canfd) NOINLINE_FUNC {
 #if !CANARD_ENABLE_CANFD
         if (canfd) {
             return false;

--- a/canard/service_client.h
+++ b/canard/service_client.h
@@ -41,6 +41,9 @@ public:
     Sender(_interface),
     server_node_id(255),
     cb(_cb) {
+#ifdef WITH_SEMAPHORE
+        WITH_SEMAPHORE(sem[index]);
+#endif
         next = branch_head[index];
         branch_head[index] = this;
     }
@@ -50,6 +53,9 @@ public:
 
     // destructor, remove the entry from the singly-linked list
     ~Client() {
+#ifdef WITH_SEMAPHORE
+        WITH_SEMAPHORE(sem[index]);
+#endif
         Client<rsptype>* entry = branch_head[index];
         if (entry == this) {
             branch_head[index] = next;

--- a/canard/service_server.h
+++ b/canard/service_server.h
@@ -41,11 +41,21 @@ public:
     HandlerList(CanardTransferTypeRequest, reqtype::cxx_iface::ID, reqtype::cxx_iface::SIGNATURE, _interface.get_index()),
     interface(_interface),
     cb(_cb) {
-        // multiple servers are not allowed, so no list
+#ifdef WITH_SEMAPHORE
+        WITH_SEMAPHORE(sem[index]);
+#endif
+        link(); // link ourselves into the handler list
     }
 
     // delete copy constructor and assignment operator
     Server(const Server&) = delete;
+
+    ~Server() {
+#ifdef WITH_SEMAPHORE
+        WITH_SEMAPHORE(sem[index]);
+#endif
+        unlink(); // unlink ourselves from the handler list
+    }
 
     /// @brief handles incoming messages
     /// @param transfer transfer object of the request

--- a/canard/service_server.h
+++ b/canard/service_server.h
@@ -37,7 +37,7 @@ public:
     /// @param _interface Interface object
     /// @param _cb Callback object
     /// @param _index HandlerList instance id
-    Server(Interface &_interface, Callback<reqtype> &_cb) : 
+    Server(Interface &_interface, Callback<reqtype> &_cb) NOINLINE_FUNC :
     HandlerList(CanardTransferTypeRequest, reqtype::cxx_iface::ID, reqtype::cxx_iface::SIGNATURE, _interface.get_index()),
     interface(_interface),
     cb(_cb) {
@@ -50,7 +50,7 @@ public:
     // delete copy constructor and assignment operator
     Server(const Server&) = delete;
 
-    ~Server() {
+    ~Server() NOINLINE_FUNC {
 #ifdef WITH_SEMAPHORE
         WITH_SEMAPHORE(sem[index]);
 #endif
@@ -59,7 +59,7 @@ public:
 
     /// @brief handles incoming messages
     /// @param transfer transfer object of the request
-    void handle_message(const CanardRxTransfer& transfer) override {
+    void handle_message(const CanardRxTransfer& transfer) override NOINLINE_FUNC {
         reqtype msg {};
         if (reqtype::cxx_iface::req_decode(&transfer, &msg)) {
             // invalid decode
@@ -74,7 +74,7 @@ public:
     /// @param transfer transfer object of the request
     /// @param msg message containing the response
     /// @return true if the response was put into the queue successfully
-    bool respond(const CanardRxTransfer& transfer, typename reqtype::cxx_iface::rsptype& msg) {
+    bool respond(const CanardRxTransfer& transfer, typename reqtype::cxx_iface::rsptype& msg) NOINLINE_FUNC {
         // encode the message
         uint32_t len = reqtype::cxx_iface::rsp_encode(&msg, rsp_buf
 #if CANARD_ENABLE_CANFD

--- a/canard/subscriber.h
+++ b/canard/subscriber.h
@@ -38,7 +38,7 @@ public:
     /// @brief Subscriber Constructor
     /// @param _cb callback function
     /// @param _index HandlerList instance id
-    Subscriber(Callback<msgtype> &_cb, uint8_t _index) :
+    Subscriber(Callback<msgtype> &_cb, uint8_t _index) NOINLINE_FUNC :
     HandlerList(CanardTransferTypeBroadcast, msgtype::cxx_iface::ID, msgtype::cxx_iface::SIGNATURE, _index),
     cb (_cb) {
 #ifdef WITH_SEMAPHORE
@@ -53,7 +53,7 @@ public:
     Subscriber(const Subscriber&) = delete;
 
     // destructor, remove the entry from the singly-linked list
-    ~Subscriber() {
+    ~Subscriber() NOINLINE_FUNC {
 #ifdef WITH_SEMAPHORE
         WITH_SEMAPHORE(sem[index]);
 #endif
@@ -74,7 +74,7 @@ public:
 
     /// @brief parse the message and call the callback
     /// @param transfer transfer object
-    void handle_message(const CanardRxTransfer& transfer) override {
+    void handle_message(const CanardRxTransfer& transfer) override NOINLINE_FUNC {
         msgtype msg {};
         if (msgtype::cxx_iface::decode(&transfer, &msg)) {
             // invalid decode

--- a/canard/subscriber.h
+++ b/canard/subscriber.h
@@ -53,6 +53,9 @@ public:
 
     // destructor, remove the entry from the singly-linked list
     ~Subscriber() {
+#ifdef WITH_SEMAPHORE
+        WITH_SEMAPHORE(sem[index]);
+#endif
         Subscriber<msgtype>* entry = branch_head[index];
         if (entry == this) {
             branch_head[index] = next;
@@ -86,9 +89,6 @@ public:
 private:
     Subscriber<msgtype>* next;
     static Subscriber<msgtype> *branch_head[CANARD_NUM_HANDLERS];
-#ifdef WITH_SEMAPHORE
-    Canard::Semaphore sem[CANARD_NUM_HANDLERS];
-#endif
     Callback<msgtype> &cb;
 };
 

--- a/canard/subscriber.h
+++ b/canard/subscriber.h
@@ -46,6 +46,7 @@ public:
 #endif
         next = branch_head[index];
         branch_head[index] = this;
+        link(); // link ourselves into the handler list now that we're in the branch list
     }
 
     // delete copy constructor and assignment operator
@@ -56,6 +57,7 @@ public:
 #ifdef WITH_SEMAPHORE
         WITH_SEMAPHORE(sem[index]);
 #endif
+        unlink(); // unlink ourselves from the handler list before the branch list
         Subscriber<msgtype>* entry = branch_head[index];
         if (entry == this) {
             branch_head[index] = next;


### PR DESCRIPTION
Avoids race conditions and crashes when adding/removing handler list items. See commits for details. Saves 1K flash on Cube Orange (as opposed to costing 2K if inlining isn't changed).

Needs testing on real hardware/applications.

Includes #75 .