### PR TITLE
Transfer type is not checked in c++ wrappers

### DIFF
--- a/canard/handler_list.h
+++ b/canard/handler_list.h
@@ -54,16 +54,17 @@ public:
     /// @brief accept a message if it is handled by this handler list
     /// @param index Index of the handler list
     /// @param msgid ID of the message/service
+    /// @param transfer_type canard tranfer type (Broadcast, request or reply)
     /// @param[out] signature Signature of the message/service
     /// @return true if the message is handled by this handler list
-    static bool accept_message(uint8_t index, uint16_t msgid, uint64_t &signature) NOINLINE_FUNC
+    static bool accept_message(uint8_t index,  uint16_t msgid, CanardTransferType transfer_type, uint64_t &signature) NOINLINE_FUNC
     {
 #ifdef WITH_SEMAPHORE
         WITH_SEMAPHORE(sem[index]);
 #endif
         HandlerList* entry = head[index];
         while (entry != nullptr) {
-            if (entry->msgid == msgid) {
+            if (entry->msgid == msgid && entry->transfer_type == transfer_type) {
                 signature = entry->signature;
                 return true;
             }

--- a/canard/interface.h
+++ b/canard/interface.h
@@ -95,10 +95,11 @@ public:
 protected:
     /// @brief forward accept_message call to indexed HandlerList
     /// @param msgid ID of the message/service
+    /// @param transfer_type - transfer type
     /// @param[out] signature signature of message/service
     /// @return true if the message/service is accepted
-    inline bool accept_message(uint16_t msgid, uint64_t &signature) {
-        return HandlerList::accept_message(index, msgid, signature);
+    inline bool accept_message(uint16_t msgid, CanardTransferType transfer_type,  uint64_t &signature) {
+        return HandlerList::accept_message(index, msgid, transfer_type, signature);
     }
 
     /// @brief forward handle_message call to indexed HandlerList

--- a/canard/tests/canard_interface.cpp
+++ b/canard/tests/canard_interface.cpp
@@ -120,7 +120,7 @@ bool CanardInterface::shouldAcceptTransfer(const CanardInstance* ins,
     (void)transfer_type;
     (void)source_node_id;
     CanardInterface* iface = (CanardInterface*) ins->user_reference;
-    return iface->accept_message(data_type_id, *out_data_type_signature);
+    return iface->accept_message(data_type_id, transfer_type, *out_data_type_signature);
 }
 
 void CanardTestNetwork::route_frame(CanardTestInterface *send_iface, const CanardCANFrame &frame, uint64_t timestamp_usec) {

--- a/canard/tests/cxx_test_interface.h
+++ b/canard/tests/cxx_test_interface.h
@@ -10,7 +10,7 @@ class TestNetwork {
 public:
     static constexpr int N = 10;
     TestNetwork() {}
-    void route_msg(CoreTestInterface *send_iface, uint8_t source_node_id, uint8_t destination_node_id, Transfer transfer);
+    void route_msg(CoreTestInterface *send_iface, uint8_t source_node_id, uint8_t destination_node_id, Transfer transfer, CanardTransferType transfer_type);
     TestNetwork(const TestNetwork&) = delete;
     TestNetwork& operator=(const TestNetwork&) = delete;
 
@@ -61,7 +61,7 @@ public:
     /// @return node id
     uint8_t get_node_id() const override { return node_id; }
 
-    void handle_transfer(CanardRxTransfer &transfer);
+    void handle_transfer(CanardRxTransfer &transfer, CanardTransferType transfer_type);
 
     void free() {
         // free transfer ids

--- a/examples/ESCNode_C++/esc_node.cpp
+++ b/examples/ESCNode_C++/esc_node.cpp
@@ -585,7 +585,7 @@ bool CanardInterface::shouldAcceptTransfer(const CanardInstance* ins,
                                    uint8_t source_node_id)
 {
     CanardInterface* iface = (CanardInterface*)ins->user_reference;
-    return iface->accept_message(data_type_id, *out_data_type_signature);
+    return iface->accept_message(data_type_id, transfer_type, *out_data_type_signature);
 }
 
 /*


### PR DESCRIPTION
fixes #79

thanks to  Mykhaylo Shcherbak.
this is an API change, will require all users of C++ API to update