### PR TITLE
Fix incorrect buffer size constant in NodeStatus examples

### DIFF
--- a/examples/BatteryNode/battery_node.c
+++ b/examples/BatteryNode/battery_node.c
@@ -568,7 +568,7 @@ static bool shouldAcceptTransfer(const CanardInstance *ins,
  */
 static void send_NodeStatus(void)
 {
-    uint8_t buffer[UAVCAN_PROTOCOL_GETNODEINFO_RESPONSE_MAX_SIZE];
+    uint8_t buffer[UAVCAN_PROTOCOL_NODESTATUS_MAX_SIZE];
 
     node_status.uptime_sec = micros64() / 1000000ULL;
     node_status.health = UAVCAN_PROTOCOL_NODESTATUS_HEALTH_OK;

--- a/examples/ESCNode/esc_node.c
+++ b/examples/ESCNode/esc_node.c
@@ -776,7 +776,7 @@ static bool shouldAcceptTransfer(const CanardInstance *ins,
  */
 static void send_NodeStatus(void)
 {
-    uint8_t buffer[UAVCAN_PROTOCOL_GETNODEINFO_RESPONSE_MAX_SIZE];
+    uint8_t buffer[UAVCAN_PROTOCOL_NODESTATUS_MAX_SIZE];
 
     node_status.uptime_sec = micros64() / 1000000ULL;
     node_status.health = UAVCAN_PROTOCOL_NODESTATUS_HEALTH_OK;

--- a/examples/RangeFinder/rangefinder.c
+++ b/examples/RangeFinder/rangefinder.c
@@ -555,7 +555,7 @@ static bool shouldAcceptTransfer(const CanardInstance *ins,
  */
 static void send_NodeStatus(void)
 {
-    uint8_t buffer[UAVCAN_PROTOCOL_GETNODEINFO_RESPONSE_MAX_SIZE];
+    uint8_t buffer[UAVCAN_PROTOCOL_NODESTATUS_MAX_SIZE];
 
     node_status.uptime_sec = micros64() / 1000000ULL;
     node_status.health = UAVCAN_PROTOCOL_NODESTATUS_HEALTH_OK;

--- a/examples/ServoNode/servo_node.c
+++ b/examples/ServoNode/servo_node.c
@@ -719,7 +719,7 @@ static bool shouldAcceptTransfer(const CanardInstance *ins,
  */
 static void send_NodeStatus(void)
 {
-    uint8_t buffer[UAVCAN_PROTOCOL_GETNODEINFO_RESPONSE_MAX_SIZE];
+    uint8_t buffer[UAVCAN_PROTOCOL_NODESTATUS_MAX_SIZE];
 
     node_status.uptime_sec = micros64() / 1000000ULL;
     node_status.health = UAVCAN_PROTOCOL_NODESTATUS_HEALTH_OK;

--- a/examples/SimpleNode/simple_node.c
+++ b/examples/SimpleNode/simple_node.c
@@ -175,7 +175,7 @@ static bool shouldAcceptTransfer(const CanardInstance *ins,
  */
 static void send_NodeStatus(void)
 {
-    uint8_t buffer[UAVCAN_PROTOCOL_GETNODEINFO_RESPONSE_MAX_SIZE];
+    uint8_t buffer[UAVCAN_PROTOCOL_NODESTATUS_MAX_SIZE];
 
     node_status.uptime_sec = micros64() / 1000000ULL;
     node_status.health = UAVCAN_PROTOCOL_NODESTATUS_HEALTH_OK;


### PR DESCRIPTION
This PR corrects an inconsistency in buffer size definitions used in NodeStatus-related example code.

Multiple C-based examples were using UAVCAN_PROTOCOL_GETNODEINFO_RESPONSE_MAX_SIZE as the buffer size when encoding uavcan_protocol_NodeStatus.

All five C language examples have been updated to use the correct constant UAVCAN_PROTOCOL_NODESTATUS_MAX_SIZE that matches the NodeStatus message size requirements.