### PR TITLE
CI: Revert "use empy 3.3.4"

### DIFF
--- a/.github/workflows/canard.yml
+++ b/.github/workflows/canard.yml
@@ -22,7 +22,7 @@ jobs:
         sudo dpkg --add-architecture i386
         sudo apt-get update
         sudo apt-get install gcc-multilib g++-multilib lcov ccache valgrind libgcc-s1:i386 libc6-dbg:i386
-        sudo pip install empy==3.3.4 pydronecan
+        sudo pip install empy pydronecan
     - name: Submodule update
       run: |
         git submodule update --init --recursive

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Install Dependencies
       run: |
         uname -a
-        sudo pip install empy==3.3.4 pydronecan pexpect
+        sudo pip install empy pydronecan pexpect
     - name: build SimpleNode
       working-directory: ${{github.workspace}}/examples/SimpleNode
       run: make

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,7 @@ and type 'make'
 
 You may need to install the following before building:
 ```
-  sudo pip install empy==3.3.4 pydronecan pexpect
+  sudo pip install empy pydronecan pexpect
 ```
 
 ## Running Examples


### PR DESCRIPTION
This reverts commit 0554371dbbc976f417dba2ff28d8a747348e9c30.

The DSDL compiler now supports empy 4 (though 3.3.4 is still supported too for now).