### PR TITLE
Add Install and Uninstall targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@
 cmake_minimum_required (VERSION 3.22.1)
 project(Canard)
 
+set(Canard_VERSION_MAJOR 0)
+set(Canard_VERSION_MINOR 2)
+set(Canard_VERSION_PATCH 0)
+set(Canard_VERSION ${Canard_VERSION_MAJOR}.${Canard_VERSION_MINOR}.${Canard_VERSION_PATCH})
+
 # check arguments for 32-bit build
 option(CMAKE_32BIT "Enable 32 bit build" OFF)
 
@@ -65,7 +70,11 @@ target_compile_options(canard_tgt PUBLIC -Wall -g)
 target_include_directories(canard_tgt
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
   )
+set_target_properties(canard_tgt PROPERTIES
+  VERSION ${Canard_VERSION}
+)
 
 add_library(canard_private_tgt canard_internals.h canard.c)
 target_compile_options(canard_private_tgt PUBLIC
@@ -103,3 +112,58 @@ if(${BUILD_TESTING})
     add_custom_command(TARGET coverage POST_BUILD COMMAND ;)
   endif()
 endif()
+
+# Install targets
+install(
+  TARGETS canard_tgt
+  EXPORT ${PROJECT_NAME}Targets
+  DESTINATION lib
+)
+
+install(
+  EXPORT ${PROJECT_NAME}Targets
+  FILE ${PROJECT_NAME}Targets.cmake
+  DESTINATION lib/cmake/${PROJECT_NAME}
+)
+
+# Install header
+install(
+  FILES canard.h
+  DESTINATION include
+)
+
+# uninstall target
+if(NOT TARGET uninstall)
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+  IMMEDIATE @ONLY)
+
+  add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+endif()
+
+include(CMakePackageConfigHelpers)
+# generate the config file that includes the exports
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+  INSTALL_DESTINATION "lib/cmake/${PROJECT_NAME}"
+  NO_SET_AND_CHECK_MACRO
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+  VERSION "${Canard_VERSION}"
+  COMPATIBILITY AnyNewerVersion
+)
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+  DESTINATION lib/cmake/${PROJECT_NAME}
+)
+
+export(EXPORT ${PROJECT_NAME}Targets
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,10 +126,16 @@ install(
   DESTINATION lib/cmake/${PROJECT_NAME}
 )
 
-# Install header
+# Install header files
 install(
   FILES canard.h
   DESTINATION include
+)
+
+install(
+  DIRECTORY canard
+  DESTINATION include/canard
+  FILES_MATCHING PATTERN "*.h"
 )
 
 # uninstall target

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ install(
 
 install(
   DIRECTORY canard
-  DESTINATION include/canard
+  DESTINATION include
   FILES_MATCHING PATTERN "*.h"
 )
 

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,0 +1,4 @@
+
+@PACKAGE_INIT@
+
+include ( "${CMAKE_CURRENT_LIST_DIR}/CanardTargets.cmake" )

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -1,0 +1,21 @@
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    execute_process(
+      COMMAND "@CMAKE_COMMAND@" -E remove "$ENV{DESTDIR}${file}"
+      OUTPUT_VARIABLE rm_out
+      RESULT_VARIABLE rm_retval
+    )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif()
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif()
+endforeach()


### PR DESCRIPTION
This PR fills out all of the necessary CMake instrumentation to make this a stand-alone, installable (and un-installable) package with instructions like:

```bash
mkdir build && cd build
cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=0
make
sudo make install
```

This installs `canard.h`, `canard/*.h`, `canard_tgt.a`, and a few CMake files which make it possible to `find_package(Canard)` in another CMake project. Also:

```bash
sudo make uninstall
```
Will remove the package and associated files which were installed.